### PR TITLE
Public IP - Curl against ifconfig.co

### DIFF
--- a/modules/ipaddr/ipaddr
+++ b/modules/ipaddr/ipaddr
@@ -44,8 +44,8 @@ else
 fi
 
 function wanip () {
-	$(hash dig 2>/dev/null) || $(myzsh error "Couldn't find application: dig" && return 1)
-	dig +short myip.opendns.com @resolver1.opendns.com
+	$(hash curl 2>/dev/null) || $(myzsh error "Couldn't find application: curl" && return 1)
+	curl ifconfig.co
 }
 
 OUTPUT=ip_func


### PR DESCRIPTION
Curl is more likely to be present on a system and doesn't require installing the entire bind-utils library.  Plus it's a shorter command.
