### PR TITLE
Fixing ipaddr display inside docker

### DIFF
--- a/modules/ipaddr/ipaddr
+++ b/modules/ipaddr/ipaddr
@@ -38,7 +38,7 @@ else
 		}
 	else
 		function ip_func () {
-                  echo "${$($IFCONFIG | awk -v ignore="$IPADDR_IGNORE_NET" '/^[a-z]/ {inf=$1} /inet addr/{gsub(/addr:/, "", $2); if(inf !~ ignore){printf inf ":" $2 " "}}')%% }"
+		   echo "${$($IFCONFIG | awk -v ignore="$IPADDR_IGNORE_NET" '/^[a-z]/ {inf=$1 gsub(/:/, "", inf)} /(inet |inet addr)/{gsub(/addr:/, "", $2); if(inf !~ ignore){printf inf ":" $2 " "}}')%% }"
 		}
 	fi
 fi


### PR DESCRIPTION
Matching for the interfaces inside a docker container running on a mac was not matching the current awk pattern.  Added additional bits to include those too.