### PR TITLE
Module like gettime but for UTC

### DIFF
--- a/modules/gettime-utc/gettime-utc
+++ b/modules/gettime-utc/gettime-utc
@@ -1,5 +1,5 @@
 time_utc_func () {
-	echo "$(date -u +\%T)"
+	echo "$(date -u +\%T+0)"
 }
 
 OUTPUT=time_utc_func

--- a/modules/gettime-utc/gettime-utc
+++ b/modules/gettime-utc/gettime-utc
@@ -1,0 +1,6 @@
+time_utc_func () {
+	echo "$(date -u +\%T)"
+}
+
+OUTPUT=time_utc_func
+# vim: filetype=zsh noexpandtab

--- a/modules/gettime-utc/info.md
+++ b/modules/gettime-utc/info.md
@@ -1,0 +1,11 @@
+## Summary
+Shows the current UTC time.
+
+## Requires
+nothing
+
+## Usage
+* Place in a prompt section of .zshrc
+
+## Description
+Prints the current UTC time in the strftime format %H:%M:%S


### PR DESCRIPTION
I wanted an easy way to see UTC in my prompt but zsh doesn't have a way to do that natively through prompt expansion.  This calls out to the `date` command returns UTC. 