### PR TITLE
Use command instead of hash to check for dependencies.

### DIFF
--- a/modules/alwaystmux/alwaystmux
+++ b/modules/alwaystmux/alwaystmux
@@ -6,10 +6,7 @@ isosx && bindkey "^[[1~" beginning-of-line && bindkey "^[[4~" end-of-line
 function _deps(){
 	app="tmux"
 
-	if ! hash $app 2>/dev/null; then
-		myzsh error "Couldn't find application ${app}"
-		return 1
-	fi
+        $(command -v $app >/dev/null 2>&1) || ( myzsh error "Couldn't find application ${app}" && return 1 )
 }
 
 if [ -z "$TMUX" ]; then

--- a/modules/git/git
+++ b/modules/git/git
@@ -4,7 +4,7 @@ globalvar GIT_FETCH_CACHE_TIME 3600 "Frequency in which the git remote cache sho
 function _deps(){
 	app="git"
 
-	$(hash $app 2>/dev/null) || ( myzsh error "Couldn't find application ${app}" && return 1 )
+        $(command -v $app >/dev/null 2>&1) || ( myzsh error "Couldn't find application ${app}" && return 1 )
 }
 
 function git () {

--- a/modules/ipaddr/ipaddr
+++ b/modules/ipaddr/ipaddr
@@ -2,13 +2,13 @@ globalvar IPADDR_IGNORE_NET "docker0|fw|gif|lo|lxcbr0|p2p|stf|utnn|vmnet" "Netwo
 
 function _deps(){
 	err=0
-	$(hash awk 2>/dev/null) || $(myzsh error "Couldn't find application: awk" && err=1)
-	$(hash ip 2>/dev/null) || $(hash ifconfig 2>/dev/null) || $(myzsh error "Couldn't find application: ip or ifconfig" && err=1)
+	$(command -v awk >/dev/null 2>&1) || $(myzsh error "Couldn't find application: awk" && err=1)
+	$(command -v ip >/dev/null 2>&1) || $(command -v ifconfig >/dev/null 2>&1) || $(myzsh error "Couldn't find application: ip or ifconfig" && err=1)
 
 	return $err
 }
 
-if $(hash ip 2>/dev/null); then
+if $(command -v ip >/dev/null 2>&1); then
 	function ip_func () {
           echo "${$(ip -o addr | awk -v ignore="$IPADDR_IGNORE_NET" '/inet /{if ($2 !~ ignore){printf $2 ":" $4 " "}}')%% }"
 	}
@@ -44,7 +44,7 @@ else
 fi
 
 function wanip () {
-	$(hash dig 2>/dev/null) || $(myzsh error "Couldn't find application: dig" && return 1)
+	$(command -v dig >/dev/null 2>&1) || $(myzsh error "Couldn't find application: dig" && return 1)
 	dig +short myip.opendns.com @resolver1.opendns.com
 }
 

--- a/modules/nvm/nvm
+++ b/modules/nvm/nvm
@@ -2,7 +2,7 @@ globalvar NVM_LOCATION "" "Location of nvm.sh"
 
 function _deps(){
   app="nvm.sh"
-  if hash $app 2>/dev/null; then
+  if command -v $app >/dev/null 2>&1; then
     source $app
   else
     source $NVM_LOCATION 2>/dev/null || $(myzsh error "Couldn't find nvm.sh, manually set NVM_LOCATION in .zshrc" && return 1)

--- a/modules/tmux/tmux
+++ b/modules/tmux/tmux
@@ -1,7 +1,7 @@
 function _deps(){
 	app="tmux"
 
-	$(hash $app 2>/dev/null) || ( myzsh error "Couldn't find application ${app}" && return 1 )
+	$(command -v $app >/dev/null 2>&1) || ( myzsh error "Couldn't find application ${app}" && return 1 )
 }
 
 # Sets the title in tmux for the current running command right before it runs

--- a/modules/vim/vim
+++ b/modules/vim/vim
@@ -1,7 +1,7 @@
 function _deps(){
 	app="vim"
 
-	$(hash $app 2>/dev/null) || ( myzsh error "Couldn't find application ${app}" && return 1 )
+	$(command -v $app >/dev/null 2>&1) || ( myzsh error "Couldn't find application ${app}" && return 1 )
 }
 
 vim_func () {

--- a/modules/virtualenvwrapper/virtualenvwrapper
+++ b/modules/virtualenvwrapper/virtualenvwrapper
@@ -2,7 +2,7 @@ globalvar VIRTUALENVWRAPPER_LOCATION "" "Location of virtualenvwrapper.sh"
 
 function _deps(){
   app="virtualenvwrapper.sh"
-  if hash $app 2>/dev/null; then
+  if command -v $app >/dev/null 2>&1; then
     source $app
   else
     source $VIRTUALENVWRAPPER_LOCATION 2>/dev/null || $(myzsh error "Couldn't find virtualenvwrapper.sh, manually set VIRTUALENVWRAPPER_LOCATION in .zshrc" && return 1)


### PR DESCRIPTION
`hash` wasn't working correctly with zsh 5.4.2.  After looking into it some more, I found out that the `hash` command we were using was bash specific and worked differently in zsh.  I found that `command` is POSIX compliant and decided to change to that based on this stackoverflow.
https://stackoverflow.com/questions/592620/how-to-check-if-a-program-exists-from-a-bash-script 