### PR TITLE
Flag to ignore alwaystmux.

### DIFF
--- a/modules/alwaystmux/alwaystmux
+++ b/modules/alwaystmux/alwaystmux
@@ -9,6 +9,8 @@ function _deps(){
         $(command -v $app >/dev/null 2>&1) || ( myzsh error "Couldn't find application ${app}" && return 1 )
 }
 
+[ "$IDE" = "true" ] && return 0
+
 if [ -z "$TMUX" ]; then
 	key=$TMUX_LOCAL_PREFIX
 	[ -n "$SSH_CLIENT" ] && key=$TMUX_REMOTE_PREFIX


### PR DESCRIPTION
Useful when using an IDE.  Just set the environment variable
"IDE"="true" and alwaystmux will be ignored for that session.

Example: Edit your settings.json file for VSCode
```
"terminal.integrated.env.osx": {
    "IDE": "true"
  }
```